### PR TITLE
fix:Initial z value in homework 9

### DIFF
--- a/homework/homework_9.ipynb
+++ b/homework/homework_9.ipynb
@@ -259,7 +259,7 @@
     {
      "data": {
       "text/plain": [
-       "-11.448714758432843"
+       "-11.448714758432835"
       ]
      },
      "execution_count": 5,
@@ -401,7 +401,7 @@
     "$$\n",
     "z_i >= (z_j - a_{ij}x_{ij}) \\forall j \\in parents\n",
     "\\implies\n",
-    "z_i - z_j >= a_{ij}x_{ij} \\forall j \\in parents\n",
+    "z_i - z_j >= - a_{ij}x_{ij} \\forall j \\in parents\n",
     "$$\n",
     "\n",
     "This final condition is just $A^Tz \\succcurlyeq a * x$ where $*$ denotes elementwise multiplication."
@@ -416,7 +416,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Minimised P_max: 0.025\n"
+      "Minimised P_max: 0.009\n"
      ]
     }
    ],
@@ -432,7 +432,7 @@
     "    0 <= x,\n",
     "    x <= x_max,\n",
     "    cp.sum(x) <= B,\n",
-    "    z[0] == 1,\n",
+    "    z[0] == 0,\n",
     "    A.T @ z >= - cp.multiply(a, x)\n",
     "]\n",
     "\n",
@@ -457,7 +457,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Minimised P_max: 0.441\n"
+      "Minimised P_max: 0.162\n"
      ]
     }
    ],
@@ -470,7 +470,7 @@
     "\n",
     "objective = cp.Minimize(z[-1])\n",
     "constraints = [\n",
-    "    z[0] == 1,\n",
+    "    z[0] == 0,\n",
     "    A.T @ z >= - cp.multiply(a, x)\n",
     "]\n",
     "\n",


### PR DESCRIPTION
Fixed initial z value in homework 9 notebook, as it was set to 1, while `z` represents the log of a probability, so if the initial probability is 1, the log is 0.

Also added a `-` sign to the markdown explanation of the same exercise (Allocation of interdiction effort).

This pull request resolves issue #1 